### PR TITLE
Add eventAltName to Journal Event Reports

### DIFF
--- a/canonn/journaldata.py
+++ b/canonn/journaldata.py
@@ -50,6 +50,7 @@ class CanonnJournal(Emitter):
         payload["cmdrName"] = self.cmdr
         payload["rawJson"] = self.entry
         payload["eventName"] = self.entry["event"]
+        payload["eventAltName"] = self.entry["Name"]
         payload["clientVersion"] = self.client
         payload["isBeta"] = self.is_beta
         if self.body:
@@ -60,6 +61,7 @@ class CanonnJournal(Emitter):
 
     def run(self):
         url = self.getUrl()
+        # Plan to migrate this over to use eventAltName in the future, no ETA yet pending CAPIv2 changes
         if not CanonnJournal.exclusions:
             debug("getting journal excludes")
             tempexcludes = {}
@@ -79,6 +81,7 @@ class CanonnJournal(Emitter):
         payload["cmdrName"] = self.cmdr
         payload["rawJson"] = self.entry
         payload["eventName"] = self.entry["event"]
+        payload["eventAltName"] = self.entry["Name"]
         payload["clientVersion"] = self.client
         if self.body:
             payload["BodyName"] = self.body

--- a/canonn/journaldata.py
+++ b/canonn/journaldata.py
@@ -28,6 +28,7 @@ class CanonnJournal(Emitter):
         self.is_beta = is_beta
         self.entry = entry.copy()
         self.client = client
+        self.eventAltName = entry.get("Name")
         if entry.get("bodyName"):
             self.body = entry.get("BodyName")
         else:
@@ -50,7 +51,7 @@ class CanonnJournal(Emitter):
         payload["cmdrName"] = self.cmdr
         payload["rawJson"] = self.entry
         payload["eventName"] = self.entry["event"]
-        payload["eventAltName"] = self.entry["Name"]
+        payload["eventAltName"] = self.eventAltName
         payload["clientVersion"] = self.client
         payload["isBeta"] = self.is_beta
         if self.body:
@@ -81,7 +82,7 @@ class CanonnJournal(Emitter):
         payload["cmdrName"] = self.cmdr
         payload["rawJson"] = self.entry
         payload["eventName"] = self.entry["event"]
-        payload["eventAltName"] = self.entry["Name"]
+        payload["eventAltName"] = self.eventAltName
         payload["clientVersion"] = self.client
         if self.body:
             payload["BodyName"] = self.body


### PR DESCRIPTION
This is to easier track what the event report is related to approach settlement for tracking Guardian Structure, eventually we will need to forward this to the /grreports endpoint but for now it's for my own sanity.