### PR TITLE
codex: fix use of uninitialized variable

### DIFF
--- a/canonn/codex.py
+++ b/canonn/codex.py
@@ -2703,15 +2703,11 @@ class CodexTypes():
                 r2 = self.radius_ly(candidate)
                 # to account for things like stars and gas giants
                 if distance is not None and r1 is not None and r2 is not None:
-                    comparitor = 2 * (r1 + r2)
-
-                if distance is not None and comparitor is not None and distance < comparitor:
-
-                    if candidate.get("isLandable"):
-                        self.add_poi(
-                            "Tourist", 'Close Orbit Landable', body_code)
-                    else:
-                        self.add_poi("Tourist", 'Close Orbit', body_code)
+                    if distance < (2 * (r1 + r2)):
+                        if candidate.get("isLandable"):
+                            self.add_poi("Tourist", 'Close Orbit Landable', body_code)
+                        else:
+                            self.add_poi("Tourist", 'Close Orbit', body_code)
 
     def close_rings(self, candidate, bodies, body_code):
 


### PR DESCRIPTION
I hit this failure today, bopping around HIP 36601. It is caused by testing a variable that has never been declared **in the scope of the test** for being `None`.

I simplified the code, eliminating the extra variable, and  in the process the error.

```
2023-01-01 22:36:31.618 UTC - ERROR - 8424:19044:19044 <plugins>.E-EDMC-Canonn-6.9.7.canonn.codex.CodexTypes.refreshPOIData:1551: cannot access local variable 'comparitor' where it is not associated with a value
Traceback (most recent call last):
  File "C:\Users\danie\AppData\Local\EDMarketConnector\plugins\E-EDMC-Canonn-6.9.7\canonn\codex.py", line 1089, in refreshPOIData
    self.close_bodies(b, bodies, body_code)
  File "C:\Users\danie\AppData\Local\EDMarketConnector\plugins\E-EDMC-Canonn-6.9.7\canonn\codex.py", line 2708, in close_bodies
    if distance is not None and comparitor is not None and distance < comparitor:
                                ^^^^^^^^^^
UnboundLocalError: cannot access local variable 'comparitor' where it is not associated with a value
```