### PR TITLE
improve EDMCOverlay lazy-loading to work more consistently.

### DIFF
--- a/load.py
+++ b/load.py
@@ -40,7 +40,8 @@ import plug
 
 this = sys.modules[__name__]
 
-plugin_name = os.path.basename(os.path.dirname(__file__))
+# stripping `EDMC-` keeps our name consistent with what EDMC displays.
+plugin_name = os.path.basename(os.path.dirname(__file__)).removeprefix('EDMC-')
 logger = logging.getLogger(f'{appname}.{plugin_name}')
 
 # If the Logger has handlers then it was already set up by the core code, else
@@ -132,7 +133,7 @@ def plugin_start(plugin_dir):
 
     canonn.target.TargetDisplay.set_plugin_dir(plugin_dir)
 
-    return 'Canonn'
+    return plugin_name
 
 
 def plugin_stop():

--- a/load.py
+++ b/load.py
@@ -69,8 +69,6 @@ this.nearloc = {
     'Time': None
 }
 
-myPlugin = "EDMC-Canonn"
-
 this.SysFactionState = None  # variable for state of controling faction
 this.SysFactionAllegiance = None  # variable for allegiance of controlling faction
 this.DistFromStarLS = None  # take distance to star


### PR DESCRIPTION
I had an error trigger because EDMCOverlay loaded in an uncommon order compared to EDMC-Canonn, 
and it revealed a bug in the current lazy-loading logic where it'd never try and load the module
again, but *would* generate an error message every time.

This fixes that; it ended up being a larger rewrite of the connection logic than I intended,
but should be much more robust.  Certainly, it survives every situation I can subject it to
correctly, recovers well, and avoids spamming me with thirty error beeps. :)