### PR TITLE
New Release

### DIFF
--- a/canonn/codex.py
+++ b/canonn/codex.py
@@ -541,7 +541,7 @@ class CodexTypes():
         self.frame.columnconfigure(0, weight=1)
         self.frame.grid(row=gridrow, column=0, sticky="NSEW", columnspan=2)
         self.frame.bind('<<refreshPOIData>>', self.refreshPOIData)
-        #self.frame.bind('<<refreshPlanetData>>', self.refreshPlanetData)
+        # self.frame.bind('<<refreshPlanetData>>', self.refreshPlanetData)
 
         self.container = Frame(self.frame, highlightthickness=1)
         self.container.grid(row=0, column=0, sticky="NSEW", columnspan=2)
@@ -560,7 +560,7 @@ class CodexTypes():
         self.systemtitle_name = HyperlinkLabel(
             self.container, text="?", url=None)  # moved to container
         self.systemtitle_name.grid(row=0, column=0, sticky="W")
-        #self.systemprogress = tk.Label(self.systemtitle, text="?")
+        # self.systemprogress = tk.Label(self.systemtitle, text="?")
         self.systemprogress = tk.Label(self.container, text="?")
         self.systemprogress.grid(
             row=0, column=1, sticky="W")  # moved to next row
@@ -613,12 +613,12 @@ class CodexTypes():
         self.organicscan = {}
         self.nfss = 0
         self.fccount = 0
-        #self.stationPlanetData = {}
+        # self.stationPlanetData = {}
 
         self.temp_poidata = None
         self.temp_spanshdata = None
 
-        #self.cmdrData = {}
+        # self.cmdrData = {}
 
         self.images_body = tk.PhotoImage(file=os.path.join(
             CodexTypes.plugin_dir, "icons", "planet.gif"))
@@ -675,7 +675,7 @@ class CodexTypes():
         # self.systemprogress.grid_remove()
 
     def nextBodyMode(self, event):
-        #Debug.logger.debug(f"nextBodyMode {self.event}")
+        # Debug.logger.debug(f"nextBodyMode {self.event}")
         if self.icon_body["text"] == "Body":
             self.switchBodyMode("Body_auto")
         elif self.icon_body["text"] == "Body_auto":
@@ -687,7 +687,7 @@ class CodexTypes():
                 self.switchBodyMode("Body_auto")
 
     def switchBodyMode(self, mode):
-        #Debug.logger.debug(f"switchBodyMode {mode}")
+        # Debug.logger.debug(f"switchBodyMode {mode}")
         if mode == "Body":
             self.planetlist_auto = False
             self.planetlist_show = True
@@ -1003,7 +1003,7 @@ class CodexTypes():
     # this seems horribly confused
     def refreshPOIData(self, event):
 
-        #Debug.logger.debug(f"refreshPOIData {self.event} {self.waitingPOI}")
+        # Debug.logger.debug(f"refreshPOIData {self.event} {self.waitingPOI}")
 
         if self.waitingPOI:
             return
@@ -1130,13 +1130,13 @@ class CodexTypes():
                             # check SAA signals
                             """  if body_code not in self.saadata:
                                 if body_code not in self.ppoidata:
-                                    #self.add_poi("Geology", "$Sites:Need DSS", body_code)
+                                    # self.add_poi("Geology", "$Sites:Need DSS", body_code)
                                     self.add_poi(
                                         "MissingData", "$Geology:Need DSS", body_code)
-                                    #self.ppoidata[body_code] = {}
+                                    # self.ppoidata[body_code] = {}
                                 else:
                                     if "Geology" not in self.ppoidata[body_code]:
-                                        #self.add_poi("Geology", "$Sites:Need DSS", body_code)
+                                        # self.add_poi("Geology", "$Sites:Need DSS", body_code)
                                         self.add_poi(
                                             "MissingData", "$Geology:Need DSS", body_code) """
 
@@ -1146,13 +1146,13 @@ class CodexTypes():
                                 "MissingData", "$Planets:Need FSS", body_code)
                             """ if body_code not in self.saadata:
                                 if body_code not in self.ppoidata:
-                                    #self.add_poi("Biology", "$Species:Need DSS", body_code)
+                                    # self.add_poi("Biology", "$Species:Need DSS", body_code)
                                     self.add_poi(
                                         "MissingData", "$Biology:Need DSS", body_code)
-                                    #self.ppoidata[body_code] = {}
+                                    # self.ppoidata[body_code] = {}
                                 else:
                                     if "Biology" not in self.ppoidata[body_code]:
-                                        #self.add_poi("Biology", "$Species:Need DSS", body_code)
+                                        # self.add_poi("Biology", "$Species:Need DSS", body_code)
                                         self.add_poi(
                                             "MissingData", "$Biology:Need DSS", body_code) """
 
@@ -1380,8 +1380,8 @@ class CodexTypes():
                         self.saadata[body_code] = {}
                     self.saadata[body_code][r.get(
                         "hud_category")] = r.get("count")
-                    #self.remove_poi("Geology", "$Sites:Need DSS", body_code)
-                    #self.remove_poi("Biology", "$Species:Need DSS", body_code)
+                    # self.remove_poi("Geology", "$Sites:Need DSS", body_code)
+                    # self.remove_poi("Biology", "$Species:Need DSS", body_code)
                     self.remove_poi(
                         "MissingData", "$Geology:Need DSS", body_code)
                     self.remove_poi(
@@ -1390,7 +1390,7 @@ class CodexTypes():
                         "MissingData", "$Planets:Need FSS", body_code)
                     self.remove_poi(
                         "MissingData", "$Rings:Need DSS", body_code)
-                    #self.remove_poi("MissingData", "$Rings:Need DSS", body_code)
+                    # self.remove_poi("MissingData", "$Rings:Need DSS", body_code)
 
                     if r.get("hud_category") == "Ring":
                         self.add_poi(
@@ -1493,7 +1493,7 @@ class CodexTypes():
                                     "body": bodyname, "coords": latlon}
 
             for station in self.stationdata:
-                Debug.logger.debug(json.dumps(self.stationdata, indent=4))
+                # Debug.logger.debug(json.dumps(self.stationdata, indent=4))
                 stype = self.stationdata[station]["type"]
                 etype = self.stationdata[station].get("economy") or "None"
                 ecotype = " [" + etype + "]"
@@ -1541,18 +1541,18 @@ class CodexTypes():
 
                 (tmpcmdr, tmpis_beta, tmpsystem, tmpstation, tmpentry, tmpstate, tmpx,
                  tmpy, tmpz, tmpbody, tmplat, tmplon, tmpclient) = self.logq.get()
-                #Debug.logger.debug(f"logq not empty {tmpentry}")
+                # Debug.logger.debug(f"logq not empty {tmpentry}")
                 # self.journal_entry(tmpcmdr, tmpis_beta, tmpsystem, tmpstation, tmpentry,
                 #                   tmpstate, tmpx, tmpy, tmpz, tmpbody, tmplat, tmplon, tmpclient)
 
         except Exception as e:
-            #line = sys.exc_info()[-1].tb_lineno
+            # line = sys.exc_info()[-1].tb_lineno
             self.add_poi("Other", 'Plugin Error', None)
             Debug.logger.error("Plugin Error")
             Debug.logger.error(e)
             Debug.logger.exception(e)
 
-        #Debug.logger.debug(f"refreshPOIData end {self.event}")
+        # Debug.logger.debug(f"refreshPOIData end {self.event}")
 
         self.visualisePOIData()
         self.visualisePlanetData()
@@ -1658,7 +1658,7 @@ class CodexTypes():
         and add it in the unknown list for this hud_category
         """
 
-        Debug.logger.debug(f"remove_ppoi {hud_category} {english_name}")
+        # Debug.logger.debug(f"remove_ppoi {hud_category} {english_name}")
 
         if body not in self.ppoidata:
             return
@@ -1674,7 +1674,7 @@ class CodexTypes():
         check if it exist in the unknown list and remove it
         """
 
-        #Debug.logger.debug(f"add_ppoi {body} {hud_category} {type}")
+        # Debug.logger.debug(f"add_ppoi {body} {hud_category} {type}")
 
         if body not in self.ppoidata:
             self.ppoidata[body] = {}
@@ -1915,7 +1915,7 @@ class CodexTypes():
             Debug.logger.debug("Triggering Event")
             debug("getPOIdata frame.event_generate <<refreshPOIData>>")
             self.frame.event_generate('<<refreshPOIData>>', when='head')
-            #self.frame.event_generate('<<refreshPlanetData>>', when='head')
+            # self.frame.event_generate('<<refreshPlanetData>>', when='head')
 
             Debug.logger.debug("Finished getting POI data in thread")
 
@@ -1966,7 +1966,7 @@ class CodexTypes():
             # reorganise data
             for entry in bio.keys():
                 for body in bio.get(entry):
-                    #Debug.logger.debug(f"{body} -> {entry}")
+                    # Debug.logger.debug(f"{body} -> {entry}")
                     # populate bodies with bodyid->genus->entry
                     if not bodies[body].get(get_genus(entry)):
                         bodies[body][get_genus(entry)] = []
@@ -1977,7 +1977,7 @@ class CodexTypes():
             for bodyid, genus in bodies.items():
 
                 for entries in genus.values():
-                    #Debug.logger.debug(f"{bodyid} -> {genus} -> {entries}")
+                    # Debug.logger.debug(f"{bodyid} -> {genus} -> {entries}")
                     # if we only have one entry we must add it regardless
                     if len(entries) == 1:
                         if not newbio.get(entries[0]):
@@ -2001,7 +2001,7 @@ class CodexTypes():
 
         self.systempanel.grid_remove()
 
-        #Debug.logger.debug(f"visualise POI Data event={self.event}")
+        # Debug.logger.debug(f"visualise POI Data event={self.event}")
 
         self.set_image("MissingData", False)
         self.set_image("Geology", False)
@@ -2032,7 +2032,7 @@ class CodexTypes():
         self.cleanPOIdata()
         # need to initialise if not exists
         self.systemtitle_name["text"] = self.system
-        #self.systemtitle_name["url"] = f"https://us-central1-canonn-api-236217.cloudfunctions.net/query/codex/biostats?id={self.system64}"
+        # self.systemtitle_name["url"] = f"https://us-central1-canonn-api-236217.cloudfunctions.net/query/codex/biostats?id={self.system64}"
         self.systemtitle_name[
             "url"] = f"https://canonn-science.github.io/canonn-signals/index.html?system={self.system64}"
 
@@ -2102,7 +2102,7 @@ class CodexTypes():
                     for poibody in self.poidata[category][type]:
                         col = ((i % 5)+1)*4
                         row = int(i/5)
-                        #row = 0
+                        # row = 0
                         label.append(tk.Label(
                             self.systemcol2[-1], text=poibody))
                         if poibody in self.ppoidata:
@@ -2124,10 +2124,10 @@ class CodexTypes():
                                         if not self.scandata[poibody][category][type]:
                                             label[-1]["text"] = "*" + \
                                                 label[-1]["text"]
-                                            #label.append(tk.Label(self.systemcol2[-1], text="(*)"))
+                                            # label.append(tk.Label(self.systemcol2[-1], text="(*)"))
                                             # theme.update(label[-1])
-                                            #label[-1].grid(row=row, column=col, sticky="NW")
-                                            #col += 1
+                                            # label[-1].grid(row=row, column=col, sticky="NW")
+                                            # col += 1
                         if category in ("Geology", "Biology", "Human", "Thargoid", "Guardian"):
                             if name == "Unknown":
                                 nunk = len(
@@ -2190,7 +2190,7 @@ class CodexTypes():
 
     def visualisePlanetData(self):
         """
-        A helper function to remove Genus when a sample of the species is 
+        A helper function to remove Genus when a sample of the species is
         already found.
         """
         def cleanPlanetData(data):
@@ -2220,14 +2220,14 @@ class CodexTypes():
                         # The genus is the only entry so we keep it
                         if isGenus and len(genuses.get(genus)) == 1:
                             newbio[specimen.get("key")] = specimen.get("value")
-                            #Debug.logger.debug(f"adding {specimen}")
+                            # Debug.logger.debug(f"adding {specimen}")
                         # we are not a genus so can always be returned
                         elif not isGenus:
-                            #Debug.logger.debug(f"adding {specimen}")
+                            # Debug.logger.debug(f"adding {specimen}")
                             newbio[specimen.get("key")] = specimen.get("value")
                         else:
                             pass
-                            #Debug.logger.debug(f"skipping {specimen}")
+                            # Debug.logger.debug(f"skipping {specimen}")
 
                 data["Biology"] = newbio
                 # Debug.logger.debug(newbio)
@@ -2239,8 +2239,8 @@ class CodexTypes():
 
         if self.planetlist_body not in self.ppoidata:
             return
-            #self.planetlist_body = None
-            #self.planetlist_show = False
+            # self.planetlist_body = None
+            # self.planetlist_show = False
 
         if not self.planetlist_show:
             return
@@ -2312,8 +2312,8 @@ class CodexTypes():
                             if category in self.scandata[self.planetlist_body]:
                                 if type in self.scandata[self.planetlist_body][category]:
                                     if not self.scandata[self.planetlist_body][category][type]:
-                                        #self.planetcol1[-1]['fg'] = "red"
-                                        #self.planetcol1[-1]['text'] = "   (*) " + type
+                                        # self.planetcol1[-1]['fg'] = "red"
+                                        # self.planetcol1[-1]['text'] = "   (*) " + type
                                         self.planetcol1[-1]['text'] = "   *" + type
 
                     if len(self.ppoidata[self.planetlist_body][category][type]) > 0:
@@ -2396,7 +2396,7 @@ class CodexTypes():
                 if b.get("name") == str(body) or b.get("name") == f"{self.system} {str(body)}" and b.get('volcanismType') and b.get('volcanismType') == 'No volcanism':
                     return
 
-        #Debug.logger.debug(f"add_poi - {hud_category} {english_name} {body}")
+        # Debug.logger.debug(f"add_poi - {hud_category} {english_name} {body}")
 
         if hud_category not in self.poidata:
             self.poidata[hud_category] = {}
@@ -2584,63 +2584,67 @@ class CodexTypes():
         return None
 
     def close_flypast(self, body, bodies, body_code):
-        for sibling in bodies.values():
-            p1 = body.get("parents")
-            p2 = sibling.get("parents")
+        try:
+            for sibling in bodies.values():
+                p1 = body.get("parents")
+                p2 = sibling.get("parents")
 
-            valid_body = True
-            valid_body = (p2 and valid_body)
-            valid_body = (p1 and valid_body)
-            valid_body = (body.get("semiMajorAxis") is not None and valid_body)
-            valid_body = (sibling.get("semiMajorAxis")
-                          is not None and valid_body)
-            valid_body = (body.get("orbitalEccentricity")
-                          is not None and valid_body)
-            valid_body = (sibling.get("orbitalEccentricity")
-                          is not None and valid_body)
-            valid_body = (body.get("orbitalPeriod") is not None and valid_body)
-            valid_body = (sibling.get("orbitalPeriod")
-                          is not None and valid_body)
-            not_self = (body.get("bodyId") != sibling.get("bodyId"))
-            valid_body = (not_self and valid_body)
+                valid_body = True
+                valid_body = (p2 and valid_body)
+                valid_body = (p1 and valid_body)
+                valid_body = (body.get("type") in (
+                    "Planet", "Star") and valid_body)
+                valid_body = (sibling.get("type") in (
+                    "Planet", "Star") and valid_body)
+                valid_body = (body.get("semiMajorAxis")
+                              is not None and valid_body)
+                valid_body = (sibling.get("semiMajorAxis")
+                              is not None and valid_body)
+                valid_body = (body.get("orbitalEccentricity")
+                              is not None and valid_body)
+                valid_body = (sibling.get("orbitalEccentricity")
+                              is not None and valid_body)
+                valid_body = (body.get("orbitalPeriod")
+                              is not None and valid_body)
+                valid_body = (sibling.get("orbitalPeriod")
+                              is not None and valid_body)
+                not_self = (body.get("bodyId") != sibling.get("bodyId"))
+                valid_body = (not_self and valid_body)
 
-            # if we share teh same parent and not the same body
-            if valid_body and str(p1[0]) == str(p2[0]):
-                a1 = self.apoapsis("semiMajorAxis", body.get(
-                    "semiMajorAxis"), body.get("orbitalEccentricity"))
-                a2 = self.apoapsis("semiMajorAxis", sibling.get(
-                    "semiMajorAxis"), sibling.get("orbitalEccentricity"))
-                p1 = self.periapsis("semiMajorAxis", body.get(
-                    "semiMajorAxis"), body.get("orbitalEccentricity"))
-                p2 = self.periapsis("semiMajorAxis", sibling.get(
-                    "semiMajorAxis"), sibling.get("orbitalEccentricity"))
-                r1 = sibling.get("radius")
-                r2 = body.get("radius")
+                # if we share teh same parent and not the same body
+                if valid_body and str(p1[0]) == str(p2[0]):
+                    a1 = self.apoapsis("semiMajorAxis", body.get(
+                        "semiMajorAxis"), body.get("orbitalEccentricity"))
+                    a2 = self.apoapsis("semiMajorAxis", sibling.get(
+                        "semiMajorAxis"), sibling.get("orbitalEccentricity"))
+                    p1 = self.periapsis("semiMajorAxis", body.get(
+                        "semiMajorAxis"), body.get("orbitalEccentricity"))
+                    p2 = self.periapsis("semiMajorAxis", sibling.get(
+                        "semiMajorAxis"), sibling.get("orbitalEccentricity"))
+                    r1 = sibling.get("radius")
+                    r2 = body.get("radius")
 
-                # we want this to be in km
-                adistance = (abs(a1 - a2) * 299792.5436) - (r1 + r2)
-                pdistance = (abs(p1 - a2) * 299792.5436) - (r1 + r2)
-                # print("distance {}, radii = {}".format(distance,r1+r2))
-                period = get_synodic_period(body, sibling)
+                    # we want this to be in km
+                    adistance = (abs(a1 - a2) * 299792.5436) - (r1 + r2)
+                    pdistance = (abs(p1 - a2) * 299792.5436) - (r1 + r2)
+                    # print("distance {}, radii = {}".format(distance,r1+r2))
+                    period = get_synodic_period(body, sibling)
 
-                debugval = {
-                    "body": body,
-                    "distance": {"apoapsis": adistance, "periapsis": pdistance},
-                    "orbitalEccentricity": body.get("orbitalEccentricity"),
-                    "orbitalInclination": body.get("orbitalEccentricity"),
-                    "argOfPeriapsis": body.get("orbitalEccentricity"),
-                    "synodicPeriod": period
-                }
-
-                # its close if less than 100km
-                collision = (adistance < 0 or pdistance < 0)
-                close = (adistance < 100 or pdistance < 100)
-                # only considering a 30 day period
-                if collision and period < 40:
-                    self.add_poi("Tourist", 'Collision Flypast', body_code)
-
-                elif close and period < 40:
-                    self.add_poi("Tourist", 'Close Flypast', body_code)
+                    # its close if less than 100km
+                    collision = (adistance < 0 or pdistance < 0)
+                    close = (adistance < 100 or pdistance < 100)
+                    # only considering a 30 day period
+                    if collision and period < 40:
+                        self.add_poi(
+                            "Tourist", 'Collision Flypast', body_code)
+                    elif close and period < 40:
+                        self.add_poi("Tourist", 'Close Flypast', body_code)
+        except Exception as e:
+            Debug.logger.error("Bodies error")
+            Debug.logger.error(body)
+            Debug.logger.error(e)
+            Debug.logger.exception(e)
+            raise
 
     def close_bodies(self, candidate, bodies, body_code):
         if candidate.get("type") == "Barycentre":
@@ -2648,7 +2652,7 @@ class CodexTypes():
 
         if candidate.get("semiMajorAxis") is not None and candidate.get("orbitalEccentricity") is not None:
             distance = None
-            #comparitor = None
+            comparitor = None
 
             if isBinary(candidate) and candidate.get("semiMajorAxis") is not None:
                 body = get_sibling(candidate, bodies)
@@ -3017,10 +3021,10 @@ class CodexTypes():
     def compare_jumponioum(self, v1, v2):
 
         if len(v1) > len(v2):
-            #Debug.logging.debug(f"{v1} vs {v2} = {v1}")
+            # Debug.logging.debug(f"{v1} vs {v2} = {v1}")
             return v1
         else:
-            #Debug.logging.debug(f"{v1} vs {v2} = {v2}")
+            # Debug.logging.debug(f"{v1} vs {v2} = {v2}")
             return v2
 
     def fake_biology(self, cmdr, system, x, y, z, planet, count, client):
@@ -3134,7 +3138,7 @@ class CodexTypes():
             self.fssdata = {}
             self.nfss = 0
             self.fccount = 0
-            #Debug.logger.debug("Calling PoiTypes")
+            # Debug.logger.debug("Calling PoiTypes")
             self.allowed = True
             self.logq.clear()
             self.logqueue = True
@@ -3368,7 +3372,7 @@ class CodexTypes():
                     self.remove_poi(
                         "Human", "Fleet Carrier ["+str(self.fccount)+"]", None)
                     self.fccount += 1
-                    #self.add_poi("Human", "$FleetCarrier:"+entry.get("SignalName"), None)
+                    # self.add_poi("Human", "$FleetCarrier:"+entry.get("SignalName"), None)
                     self.add_poi(
                         "Human", "Fleet Carrier ["+str(self.fccount)+"]", None)
                 else:

--- a/canonn/release.py
+++ b/canonn/release.py
@@ -35,7 +35,7 @@ from ttkHyperlinkLabel import HyperlinkLabel
 
 
 class ClientVersion():
-    ver = "7.0.0"
+    ver = "7.0.1"
     client_version = f"EDMC-Canonn.{ver}"
 
     @classmethod

--- a/canonn/release.py
+++ b/canonn/release.py
@@ -95,7 +95,7 @@ class ReleaseLink(HyperlinkLabel):
 
 class ReleaseThread(threading.Thread):
     def __init__(self, release):
-        threading.Thread.__init__(self)
+        threading.Thread.__init__(self, name="canonn-ReleaseThread")
         self.release = release
 
     def run(self):
@@ -148,7 +148,9 @@ class Release(Frame):
 
         Debug.logger.debug(config.get_str('Canonn:RemoveBackup'))
 
-        self.update(None)
+        # trigger the update *after* the Tk main loop is running, since it can get the result and
+        # try and send a Tk event before EDMC manages to get the main loop started.
+        self.after_idle(self.update, None)
 
         if self.rmbackup.get() == 1 and config.get_str('Canonn:RemoveBackup') and config.get_str('Canonn:RemoveBackup') != "None":
             delete_dir = config.get_str('Canonn:RemoveBackup')

--- a/canonn/systems.py
+++ b/canonn/systems.py
@@ -113,8 +113,18 @@ class Systems():
 
     @classmethod
     def systemFromId64(cls, id64):
-        return cls.id_cache.get(id64)
-        # we could try and lookup up from somewhere
+        if cls.id_cache.get(id64):
+            return cls.id_cache.get(id64)
+        else:
+            # look up the system name and coords from spansh
+            Debug.logger.debug("Fetching System From Spansh")
+            r = requests.get(f"https://spansh.co.uk/api/dump/{id64}")
+            if requests.codes.ok:
+                j = r.json().get("system")
+                cls.storeId64(
+                    {"SystemAddress": id64, "StarSystem": j.get("name")})
+                cls.storeSystem(j.get("name"), j.get("coords"))
+                return cls.id_cache.get(id64)
 
     @classmethod
     def edsmGetSystem(cls, system):

--- a/load.py
+++ b/load.py
@@ -178,6 +178,8 @@ def plugin_app(parent):
 
 
 def journal_entry(cmdr, is_beta, system, station, entry, state):
+    if entry.get("StarSystem") and entry.get("StarPos"):
+        Systems.storeSystem(entry.get("StarSystem"), entry.get("StarPos"))
 
     # we will cache some date from the latest journal because we will probably need it.
     if entry.get("event" == "LoadGame"):
@@ -202,9 +204,6 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
             x, y, z = Systems.edsmGetSystem(system)
         else:
             Debug.logger.debug("Can't locate system leaving it blank")
-
-    if entry.get("StarSystem") and entry.get("StarPos"):
-        Systems.storeSystem(entry.get("StarSystem"), entry.get("StarPos"))
 
     if "SystemFaction" in entry:
 
@@ -239,7 +238,7 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
         Systems.storeSystem(system, entry.get("StarPos"))
         this.DistFromStarLS = None
 
-    if entry.get("event") == "CarrierJump":
+    if entry.get("event") == "CarrierJump" and entry.get("StarSystem"):
         system = entry.get("StarSystem")
         Systems.storeSystem(system, entry.get("StarPos"))
 
@@ -257,6 +256,22 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
 
     if system and entry.get("StarPos"):
         x, y, z = entry.get("StarPos")
+
+    ignorelist = ["LoadGame", "Statistics", "Friends",
+                  "ReceiveText", "FSSSignalDiscovered", "SquadronStartup"]
+
+    mismatch64 = (entry.get("SystemAddress") and entry.get(
+        "SystemAddress") != Systems.id64FromSystem(system))
+    badsystem = (system is None or system == "" or mismatch64)
+
+    if badsystem and not entry.get("event") in ignorelist:
+        if system is None or system == "":
+            #plug.show_error(f"Canonn: system is blank {entry.get('event')}")
+            Debug.logger.error(f"Canonn: system is blank {entry.get('event')}")
+        else:
+            #plug.show_error(f"Canonn: id64 mismatch {entry.get('event')}")
+            Debug.logger.error(f"Canonn: id64 mismatch {entry.get('event')}")
+        Debug.logger.error(entry)
 
     return journal_entry_wrapper(cmdr, is_beta, system, this.SysFactionState, this.SysFactionAllegiance,
                                  this.DistFromStarLS, station, entry,


### PR DESCRIPTION
The plugin release thread was started when EDMC created the Tk widgets
for the UI.  If a new release was found a custom Tk event was queued to
notify the user from the UI thread.

Unfortunately, if EDMC was slow, or github especially efficient, the
release check could finish *before* EDMC had entered the Tk main loop.

That led to an exception from tkinter, since it only waits 1.5 seconds
for the main loop to start before giving up.

This changes the logic to use `.after_idle`, which will start the update
check the next time the Tk main loop is idle.  That ensures the check is
always running *after* the main loop has started.

Users shouldn't experience any significant latency: the main loop will
idle more or less immediately after being entered the first time, and
the user wouldn't see our notification before then in any case.

This fixes this exception:

    Exception in thread Thread-7:
    Traceback (most recent call last):
      File "threading.pyc", line 1038, in _bootstrap_inner
      File "C:\Users\danie\AppData\Local\EDMarketConnector\plugins\E-EDMC-Canonn\canonn\release.py", line 103, in run
        self.release.release_pull()
      File "C:\Users\danie\AppData\Local\EDMarketConnector\plugins\E-EDMC-Canonn\canonn\release.py", line 193, in release_pull
        self.event_generate('<<ReleaseUpdate>>', when='tail')
      File "tkinter\__init__.pyc", line 1914, in event_generate