### PR TITLE
fix `systemFromId64` treating an HTTP 404 response as successful

### DIFF
--- a/canonn/systems.py
+++ b/canonn/systems.py
@@ -119,7 +119,7 @@ class Systems():
             # look up the system name and coords from spansh
             Debug.logger.debug("Fetching System From Spansh")
             r = requests.get(f"https://spansh.co.uk/api/dump/{id64}")
-            if requests.codes.ok:
+            if r.ok:
                 j = r.json().get("system")
                 cls.storeId64(
                     {"SystemAddress": id64, "StarSystem": j.get("name")})


### PR DESCRIPTION
The check for a successful response from Spansh was incorrectly checking a constant, rather than the response we got back.

This updates it to ask the response object for "are you ok?" which should fix the problem.  (now, will return None if Spansh don't know about the system.)