### PR TITLE
storeSystem - set pos as list from dictionary

### DIFF
--- a/canonn/systems.py
+++ b/canonn/systems.py
@@ -82,7 +82,7 @@ class Systems():
         if not system in cls.systemCache:
             if type(pos) is dict:
                 # we will assume x y z in correct order
-                pos = pos.values()
+                pos = list(pos.values())
             cls.systemCache[system] = pos
 
     @classmethod


### PR DESCRIPTION
## Type Error

System position from spansh is stored in cache as dict_values on FSDTarget event which when retrieved later in patrols during the FSDJump event and is not usable as the list that patrols is expecting. This change forces the dict_values to become stored as a list.

### Steps To Reproduce

1. Launch game and connect
2. Launch EDMC
3. Open galmap
4. Target known system - FSDTarget event caches system pos as `dict_values`
5. Plot route to targeted system
6. Jump to system

Follow steps 3-6 to reporduce every jump. A consequence of this is that
POI distances will not update.

### Error

```
2023-04-02 17:12:58.009 UTC - ERROR - 14668:9136:9136 plug.notify_journal_entry:320: Plugin "EDMC-Canonn-7.0.2" failed
Traceback (most recent call last):
  File "C:\Users\plsck\PythonProjects\EDMarketConnector\plug.py", line 317, in notify_journal_entry
    newerror = journal_entry(cmdr, is_beta, system, station, dict(entry), dict(state))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\plsck\AppData\Local\EDMarketConnector\plugins\EDMC-Canonn-7.0.2\load.py", line 274, in journal_entry
    return journal_entry_wrapper(cmdr, is_beta, system, this.SysFactionState, this.SysFactionAllegiance,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\plsck\AppData\Local\EDMarketConnector\plugins\EDMC-Canonn-7.0.2\load.py", line 296, in journal_entry_wrapper
    this.patrol.journal_entry(cmdr, is_beta, system, station, entry, state,
  File "C:\Users\plsck\AppData\Local\EDMarketConnector\plugins\EDMC-Canonn-7.0.2\canonn\patrol.py", line 1287, in journal_entry
    self.update()
  File "C:\Users\plsck\AppData\Local\EDMarketConnector\plugins\EDMC-Canonn-7.0.2\canonn\patrol.py", line 410, in update
    self.nearest = self.getNearest(p)
                   ^^^^^^^^^^^^^^^^^^
  File "C:\Users\plsck\AppData\Local\EDMarketConnector\plugins\EDMC-Canonn-7.0.2\canonn\patrol.py", line 1042, in getNearest
    if getDistance(location, patrol.get("coords")) < getDistance(location, nearest.get("coords")):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\plsck\AppData\Local\EDMarketConnector\plugins\EDMC-Canonn-7.0.2\canonn\patrol.py", line 1355, in getDistance
    return math.sqrt(sum(tuple([math.pow(p[i] - g[i], 2) for i in range(3)])))
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\plsck\AppData\Local\EDMarketConnector\plugins\EDMC-Canonn-7.0.2\canonn\patrol.py", line 1355, in <listcomp>
    return math.sqrt(sum(tuple([math.pow(p[i] - g[i], 2) for i in range(3)])))
                                         ~^^^
TypeError: 'dict_values' object is not subscriptable
```

### Associated Journal Events

#### FSDTarget Event

```
{ "timestamp":"2023-04-02T17:11:22Z", "event":"FSDTarget", "Name":"Phoi Aub MA-H b14-16", "SystemAddress":35783656820345, "StarClass":"M", "RemainingJumpsInRoute":1 }
```

#### FSDJump Event

```
{ "timestamp":"2023-04-02T17:12:56Z", "event":"FSDJump", "Taxi":false, "Multicrew":false, "StarSystem":"Phoi Aub MA-H b14-16", "SystemAddress":35783656820345, "StarPos":[-5341.90625,762.75000,26130.93750], "SystemAllegiance":"", "SystemEconomy":"$economy_None;", "SystemEconomy_Localised":"None", "SystemSecondEconomy":"$economy_None;", "SystemSecondEconomy_Localised":"None", "SystemGovernment":"$government_None;", "SystemGovernment_Localised":"None", "SystemSecurity":"$GAlAXY_MAP_INFO_state_anarchy;", "SystemSecurity_Localised":"Anarchy", "Population":0, "Body":"Phoi Aub MA-H b14-16 A", "BodyID":1, "BodyType":"Star", "JumpDist":1.336, "FuelUsed":0.002676, "FuelLevel":10.742500 }
```
